### PR TITLE
Fix TS6.0 build failure: drop deprecated baseUrl

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,11 +3,10 @@
     "target": "ESNext",
     "jsx": "preserve",
     "lib": ["DOM", "ESNext"],
-    "baseUrl": ".",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "paths": {
-      "@/*": ["src/*"]
+      "@/*": ["./src/*"]
     },
     "resolveJsonModule": true,
     "types": ["vite/client"],


### PR DESCRIPTION
## Problem

CI run [27458665998](https://github.com/wxx9248/repo.wxx9248.top/actions/runs/27458665998) fails at the **Building index page** step (`pnpm build` → `vue-tsc --noEmit`):

```
tsconfig.json(6,5): error TS5101: Option 'baseUrl' is deprecated and will stop functioning in TypeScript 7.0.
```

The breaking change came from #695 (`Bump typescript from 5.9.3 to 6.0.3`). TypeScript 6.0 turns the deprecated `baseUrl` option into a hard error.

## Fix

Remove `baseUrl` and make the `@/*` path mapping relative (`./src/*`). Since TypeScript 5.0, `paths` resolves relative to `tsconfig.json` when `baseUrl` is unset, so this preserves identical module resolution. No source imports relied on `baseUrl` for bare-specifier resolution.

## Verification

`vue-tsc --noEmit` passes locally with exit code 0 (after generating `src/index.ts` via the index step, as CI does).

🤖 Generated with [Claude Code](https://claude.com/claude-code)